### PR TITLE
Fix `andThen` does not match the interface

### DIFF
--- a/src/RemoteData.rei
+++ b/src/RemoteData.rei
@@ -14,7 +14,7 @@ let mapError: ('e => 'f, t('a, 'p, 'e)) => t('a, 'p, 'f);
 
 let mapBoth: ('a => 'b, 'e => 'f, t('a, 'p, 'e)) => t('b, 'p, 'f);
 
-let andThen: ('a => t('b, 'p, 'e), t('a, 'p, 'e)) => t('b, 'p, 'e);
+let andThen: ('a => t('a, 'p, 'e), t('a, 'p, 'e)) => t('a, 'p, 'e);
 
 let withDefault: ('a, t('a, 'p, 'e)) => 'a;
 


### PR DESCRIPTION
As title.

After fixed the interface, you'll get an error by running `yarn build`:
```bash
  We've found a bug for you!
  /home/jihchi/repos/remotedata-re/__tests__/RemoteData_test.re 9:18-36

   7 │ describe("RemoteData", () => {
   8 │   describe("NotAsked", () => {
   9 │     let actual = RemoteData.NotAsked;
  10 │     test("isNotAsked to be true", () =>
  11 │       actual |> RemoteData.isNotAsked |> expect |> toBe(true)

  The variant constructor RemoteData.NotAsked can't be found.

  - If it's defined in another module or file, bring it into scope by:
    - Annotating it with said module name: let food = MyModule.Apple
    - Or specifying its type: let food: MyModule.fruit = Apple
  - Constructors and modules are both capitalized. Did you want the latter?
    Then instead of let foo = Bar, try module Foo = Bar.

ninja: build stopped: subcommand failed.
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

I don't know why. Temporary workaround is to delete `RemoteData.rei` file.