### PR TITLE
Upgrade bs-platform to 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.2",
-    "bs-platform": "^2.1.0",
+    "bs-platform": "^3.1.3",
     "concurrently": "^3.5.1"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "devDependencies": {
     "@glennsl/bs-jest": "^0.4.2",
-    "bs-platform": "^3.1.3",
+    "bs-platform": "^3.1.4",
     "concurrently": "^3.5.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "bs-platform": "^3.1.3",
     "concurrently": "^3.5.1"
   },
+  "peerDependencies": {
+    "bs-platform": "^3.1.3"
+  },
   "scripts": {
     "build": "bsb -make-world -clean-world",
     "setup": "bsb -make-world",

--- a/src/RemoteData.rei
+++ b/src/RemoteData.rei
@@ -18,7 +18,7 @@ let andThen: ('a => t('b, 'p, 'e), t('a, 'p, 'e)) => t('b, 'p, 'e);
 
 let withDefault: ('a, t('a, 'p, 'e)) => 'a;
 
-let fromResult: Js.Result.t('a, 'e) => t('a, 'p, 'e);
+let fromResult: Belt.Result.t('a, 'e) => t('a, 'p, 'e);
 
 let toOption: t('a, 'p, 'e) => option('a);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,9 +447,9 @@ browser-resolve@^1.11.2:
   dependencies:
     resolve "1.1.7"
 
-bs-platform@^2.1.0:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-2.2.3.tgz#d905ae10a5f3621e6a739041dfa0b58483a2174f"
+bs-platform@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.3.tgz#95c70584735e2b50922f5347159d6d89180231f6"
 
 bser@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,9 +447,9 @@ browser-resolve@^1.11.2:
   dependencies:
     resolve "1.1.7"
 
-bs-platform@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.3.tgz#95c70584735e2b50922f5347159d6d89180231f6"
+bs-platform@^3.1.4:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-3.1.4.tgz#fe8495443b35aff73dfb61cba1e6d7b88311910b"
 
 bser@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR contains breaking change because of `Belt.Result`.