### PR TITLE
Bump to react-jsx 3

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,7 +1,7 @@
 {
   "name": "remotedata-re",
   "reason": {
-    "react-jsx": 2
+    "react-jsx": 3
   },
   "warnings": {
     "error" : "+101"


### PR DESCRIPTION
This change fixes a compilation error with bsb 8.3.1:

  Error: Unsupported jsx version 2
  For more details, please checkout the schema
  https://rescript-lang.org/docs/manual/latest/build-configuration#reason-refmt-old