### PR TITLE
update definition of andThen to support mapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remotedata-re",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Tools for fetching data from remote sources in Reason",
   "main": "lib/js/src/remotedata.js",
   "repository": "git@github.com:lrosa007/remotedata-re.git",

--- a/src/RemoteData.re
+++ b/src/RemoteData.re
@@ -42,9 +42,9 @@ let mapBoth = (successFn, errorFn) => mapError(errorFn) @! map(successFn);
 let andThen = (f, data) =>
   switch (data) {
   | Success(a) => f(a)
-  | Failure(_) => data
-  | NotAsked => data
-  | Loading(_) => data
+  | Failure(v) => Failure(v)
+  | NotAsked => NotAsked
+  | Loading(v) => Loading(v)
   };
 
 let withDefault = (default, data) =>

--- a/src/RemoteData.rei
+++ b/src/RemoteData.rei
@@ -18,7 +18,7 @@ let mapError: ('e => 'f, t('a, 'p, 'e)) => t('a, 'p, 'f);
 
 let mapBoth: ('a => 'b, 'e => 'f, t('a, 'p, 'e)) => t('b, 'p, 'f);
 
-let andThen: ('a => t('a, 'p, 'e), t('a, 'p, 'e)) => t('a, 'p, 'e);
+let andThen: ('a => t('b, 'p, 'e), t('a, 'p, 'e)) => t('b, 'p, 'e);
 
 let withDefault: ('a, t('a, 'p, 'e)) => 'a;
 


### PR DESCRIPTION
The existing definition requires the type of success to the stay the same. This change allows for a mapping function to be used, is true to the original definition of this function from the inspiration repo, and does a minor version bump to indicate that the signature has changed (this may not be necessary, that's a very elmish thing).

see https://github.com/krisajenkins/remotedata/blob/master/src/RemoteData.elm#L245 for the original definition